### PR TITLE
Adicionado .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Imagens
+*.gif binary
+*.jpg binary
+*.png binary


### PR DESCRIPTION
Diz para o git que imagens devem ser tradadas como arquivos binários e evita corromper o arquivo ao dar conflito.