### PR TITLE
PG-32 - Teste não está identificando erros corretamente

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
   - DB=pg
 
 script:
-  - bash -c "[ '$DB' == 'pg' ] && psql -U postgres -f PostgreSQL/MinhaCaixa.sql"
+  - bash -c "[ '$DB' == 'pg' ] && (psql -U postgres -f PostgreSQL/MinhaCaixa.sql 2> errors; cat errors; exit \"\$(cat errors | wc -l)\")"


### PR DESCRIPTION
Melhorado testes do postgres para validar erros na execução do script.

Obs: O build desta branch irá falhar, uma vez que o script encontra-se com problemas.